### PR TITLE
Checking for l9+ directory structure.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,10 +21,10 @@
     },
     "require": {
         "php" : "^7.2.5 || ^8.0",
-        "laravel/framework": "^6.0 || ^7.0 || ^8.0"
+        "laravel/framework": "^6.0 || ^7.0 || ^8.0 || ^9.0"
     },
     "require-dev": {
-        "laravel/laravel": "8.x-dev",
+        "laravel/laravel": "9.x-dev",
         "phpunit/phpunit": "^9.0"
     },
     "scripts": {

--- a/src/I18nServiceProvider.php
+++ b/src/I18nServiceProvider.php
@@ -45,7 +45,8 @@ class I18nServiceProvider extends ServiceProvider
      */
     protected function translations()
     {
-        $translations = collect(File::directories(resource_path('lang')))->mapWithKeys(function ($dir) {
+        $lang_dir = is_dir(base_path('lang')) ? base_path('lang') : resource_path('lang');
+        $translations = collect(File::directories($lang_dir))->mapWithKeys(function ($dir) {
             return [
                 basename($dir) => collect($this->getFiles($dir))->flatMap(function ($file) {
                     return [


### PR DESCRIPTION
This PR checks for the top-level `lang` folder on Laravel 9+, and if not present falls back to the `resources/lang` folder. Given the `laravel/laravel` dev dependency it doesn't seem possible to update the tests suite to test for both versions.