### PR TITLE
Json file translations

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,11 +206,6 @@ This way only the current translations are pushed to the window object and not a
 
 > Note: On local environment the cached views are getting cleared to keep translations fresh.
 
-## Limitations
-
-The JSON file translations are not supported! Only the PHP array based key - value translations can be used.
-Also, please pay attention to place and use the tranlations the way Laravel requires it.
-
 ## Contribute
 
 If you found a bug or you have an idea connecting the package, feel free to open an issue.

--- a/tests/I18nTest.php
+++ b/tests/I18nTest.php
@@ -9,13 +9,16 @@ class I18nTest extends TestCase
     /** @test */
     public function translations_can_be_printed_via_blade_directive()
     {
-        $this->get('/i18n/translations')->assertSee(json_encode(trans('auth')), false);
+        $this->get('/i18n/translations')
+            ->assertSee(json_encode(trans('auth')), false)
+            ->assertSee('"This is a JSON test":"This is a JSON test"', false);
     }
 
     /** @test */
     public function translations_can_have_custom_key()
     {
-        $this->get('/i18n/custom-key')->assertSee("window['custom'] = ", false);
+        $this->get('/i18n/custom-key')
+            ->assertSee("window['custom'] = ", false);
     }
 
     /** @test */
@@ -24,11 +27,13 @@ class I18nTest extends TestCase
         App::setLocale('hu');
         $this->get('/i18n/translations')
             ->assertSee(json_encode(trans('auth')), false)
+            ->assertSee('"This is a JSON test":"Ez egy JSON teszt"', false)
             ->assertSee('"i18n::":{"messages":{"test":"Teszt"}', false);
 
         App::setLocale('en');
         $this->get('/i18n/translations')
             ->assertSee(json_encode(trans('auth')), false)
+            ->assertSee('"This is a JSON test":"This is a JSON test"', false)
             ->assertSee('"i18n::":{"messages":{"test":"Test"}', false);
     }
 
@@ -38,6 +43,7 @@ class I18nTest extends TestCase
         App::setLocale('fr');
         $this->get('/i18n/translations')
             ->assertSee(json_encode(trans('auth')), false)
+            ->assertSee('"This is a JSON test":"This is a JSON test"', false)
             ->assertSee('"i18n::":{"messages":{"test":"Test"}', false);
     }
 }

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -4,6 +4,7 @@ namespace Pine\I18n\Tests;
 
 use Illuminate\Foundation\Testing\TestCase as BaseTestCase;
 use Illuminate\Support\Facades\Artisan;
+use Illuminate\Support\Facades\File;
 use Illuminate\Support\Facades\Route;
 use Illuminate\Support\Facades\View;
 use Pine\I18n\Tests\CreatesApplication;
@@ -16,8 +17,14 @@ abstract class TestCase extends BaseTestCase
     {
         parent::setUp();
 
+        app()->setBasePath(__DIR__ . '/app');
+
+        // clean up default language dir that laravel publishes
+        File::deleteDirectory(base_path('/lang/en'));
+
         $this->app['translator']->addNamespace('i18n', __DIR__.'/lang');
 
+        Artisan::call('cache:clear');
         Artisan::call('view:clear');
 
         Artisan::call('lang:publish');
@@ -27,5 +34,13 @@ abstract class TestCase extends BaseTestCase
         Route::get('/i18n/{view}', function ($view) {
             return view("i18n::{$view}");
         });
+    }
+
+    public function tearDown(): void
+    {
+        parent::tearDown();
+
+        // clean up default language dir that laravel publishes
+        File::deleteDirectory(base_path('/lang/en'));
     }
 }

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -18,6 +18,8 @@ abstract class TestCase extends BaseTestCase
 
         $this->app['translator']->addNamespace('i18n', __DIR__.'/lang');
 
+        Artisan::call('view:clear');
+
         Artisan::call('lang:publish');
 
         View::addNamespace('i18n', __DIR__.'/views');

--- a/tests/app/lang/en.json
+++ b/tests/app/lang/en.json
@@ -1,0 +1,3 @@
+{
+  "This is a JSON test": "This is a JSON test"
+}

--- a/tests/app/lang/hu.json
+++ b/tests/app/lang/hu.json
@@ -1,0 +1,3 @@
+{
+  "This is a JSON test": "Ez egy JSON teszt"
+}


### PR DESCRIPTION
I've added support for loading `.json` Translation files from the Application's `lang` dir.

Because the Laravel documentation describes some special cases to avoid, e.g. if a `.json` Files' translation key collides with a translation namespace, i've tried to replicate that behavior as best as possible, with the Principle of Least Surprise.

If Laravel has weird behavior, we should replicate that weird behavior.

Unit tests are also updated to clear the view cache before each run, as the tests sometimes wouldn't recognize my changes.